### PR TITLE
Forward declare IPropertyManager as a struct not a class

### DIFF
--- a/CoralKernel/CoralKernel/Context.h
+++ b/CoralKernel/CoralKernel/Context.h
@@ -15,7 +15,7 @@ namespace coral
 {
 
   class IPluginManager;
-  class IPropertyManager;
+  struct IPropertyManager;
   class PluginManager;
 
   /// The context singleton class.


### PR DESCRIPTION
This change makes the forward declaration match the full declaration and silences a clang warning.