### PR TITLE
Bug fix for the DB connection lifetime

### DIFF
--- a/ConnectionService/src/ConnectionHandle.cpp
+++ b/ConnectionService/src/ConnectionHandle.cpp
@@ -170,7 +170,7 @@ coral::ConnectionService::ConnectionHandle::newSession( const std::string& schem
             log << coral::Warning << "Failure while attempting to start a session on connection to service " << m_info->m_serviceName << ": "<< exc.what() << coral::MessageStream::endmsg;
           }
           if( !started ) {
-            if ( (coral::TimeStamp::now(true).time()-startSessionAttempt.time()).seconds() < m_info->m_configuration.connectionRetrialTimeOut() ) {
+            if ( (coral::TimeStamp::now(true).time()-startSessionAttempt.time()).total_seconds() < m_info->m_configuration.connectionRetrialTimeOut() ) {
               log << coral::Warning << "Failed to connect to service " << m_info->m_serviceName << ": retry after "<< m_info->m_configuration.connectionRetrialPeriod() << " seconds" << coral::MessageStream::endmsg;
               coral::sleepSeconds(m_info->m_configuration.connectionRetrialPeriod());
             } else {
@@ -264,7 +264,7 @@ coral::ConnectionService::ConnectionHandle::isIdle() const
 bool
 coral::ConnectionService::ConnectionHandle::isExpired() const
 {
-  return ( coral::TimeStamp::now(true).time()-m_info->m_startIdle.time()).seconds() >= m_info->m_configuration.connectionTimeOut();
+  return ( coral::TimeStamp::now(true).time()-m_info->m_startIdle.time()).total_seconds() >= m_info->m_configuration.connectionTimeOut();
 }
 
 /// returns the specific time-out of the connection

--- a/ConnectionService/src/ReplicaCatalogue.cpp
+++ b/ConnectionService/src/ReplicaCatalogue.cpp
@@ -79,7 +79,7 @@ coral::ConnectionService::ReplicaCatalogue::isConnectionExcluded( const std::str
   if(iConn!=m_excludedConnections.end()) {
     coral::MessageStream log( m_serviceConfiguration.serviceName() );
 
-    excluded = (( coral::TimeStamp::now(true).time().time_of_day().seconds()-iConn->second.time_of_day().seconds()) < m_serviceConfiguration.missingConnectionExclusionTime() );
+    excluded = (( coral::TimeStamp::now(true).time().time_of_day().total_seconds()-iConn->second.time_of_day().total_seconds()) < m_serviceConfiguration.missingConnectionExclusionTime() );
     if(!excluded) {
       m_excludedConnections.erase(iConn);
       log << coral::Debug << "Service " << serviceName << " (technology=\""<<technologyName<<"\") has been re-admitted in the list of replicas." << coral::MessageStream::endmsg;


### PR DESCRIPTION
This PR is meant to solve a critical issue in the Connection pooling provided for all the DB technologies supported. 
The bug caused the permanent lifetime for connection whose lifetime was defined > 60 sec. In particular, no lifetime defined was falling in this category, since the default value for the lifetime is 300 sec. 
The effect of this bug was essentially the indefinite increasing of the idle connections in the pool.  It was likely NOT impacting the UPDATE access patterns on Oracle (since they are usually using a single connection ), but it appeared to be very disrupting on the READ-ONLY access pattern with frequent queries on Frontier. 
The fix is very simple, involve only 2 classes and it has been tested, showing that it solved the memory leak problem due to the increasing connection in the idle pool.