### PR TITLE
Fix for limiting idle connection pool size

### DIFF
--- a/ConnectionService/src/ConnectionHandle.cpp
+++ b/ConnectionService/src/ConnectionHandle.cpp
@@ -103,8 +103,6 @@ coral::ConnectionService::ConnectionHandle::open()
   return m_info->m_open;
 }
 
-/*
-/// THIS IS NEVER CALLED! (AV 22.07.2010)
 /// finalize (and invalidate) the connection.
 bool
 coral::ConnectionService::ConnectionHandle::close()
@@ -115,7 +113,6 @@ coral::ConnectionService::ConnectionHandle::close()
   }
   return ret;
 }
-*/
 
  /// returns true if the connection is valid
 bool

--- a/ConnectionService/src/ConnectionHandle.h
+++ b/ConnectionService/src/ConnectionHandle.h
@@ -105,11 +105,8 @@ namespace coral
       // initialize the connection
       bool open();
 
-      /*
-      /// THIS IS NEVER CALLED! (AV 22.07.2010)
       /// finalize (and invalidate) the connection.
       bool close();
-      */
 
       /// returns true if the connection is in open state
       bool isOpen() const;

--- a/ConnectionService/src/ConnectionPool.cpp
+++ b/ConnectionService/src/ConnectionPool.cpp
@@ -302,12 +302,19 @@ coral::ConnectionService::ConnectionPool::releaseConnection( ConnectionHandle& c
       // if time out is set>0, move the idle connection to idle pool
       if ( connection.specificTimeOut()>0 )
       {
-        m_idleConnections.add( connection );
-        log << coral::Debug
-            << "The valid active connection id=" << connection.connectionId()
-            << " to service \"" << connection.serviceName()
-            << "\" has been moved to the idle list."
-            << coral::MessageStream::endmsg;
+        if( m_idleConnections.size() < MAX_POOL_SIZE ){
+	  m_idleConnections.add( connection );
+	  log << coral::Debug
+	      << "The valid active connection id=" << connection.connectionId()
+	      << " to service \"" << connection.serviceName()
+	      << "\" has been moved to the idle list."
+	      << coral::MessageStream::endmsg;
+        } else {
+	  log << coral::Warning
+	      << "The Idle Connection Pool has reached the maximum size=200" 
+	      << coral::MessageStream::endmsg;         
+	  connection.close();
+	}
       }
     }
     else
@@ -391,6 +398,7 @@ coral::ConnectionService::ConnectionPool::cleanUpTimedOutConnections()
          vecIter++ )
     {
       log << coral::Debug << "The timed-out idle connection id="<<(*vecIter)->connectionId()<<" to service \""<<(*vecIter)->serviceName() << "\" has been removed from the pool." << coral::MessageStream::endmsg;
+      (*vecIter)->close();
       m_idleConnections.remove( *vecIter );
     }
   }

--- a/ConnectionService/src/ConnectionPool.h
+++ b/ConnectionService/src/ConnectionPool.h
@@ -18,6 +18,9 @@ namespace coral {
     class ConnectionPool {
 
     public:
+      const static unsigned int MAX_POOL_SIZE = 200; 
+
+    public:
 
       /// constructor
       explicit ConnectionPool( const ConnectionServiceConfiguration& configuration );


### PR DESCRIPTION
We are introducing a limit for the number of idle connections that are saved for later re-use in the idle pool.  The limit is 200, hard-coded.  When the pool is full, new connections are closed and no longer saved. 

This fix is relevant for hlt-related workflows running on reply mode, where the latency between the lumisection switch is short and causes the pile-up of frontier-related file descriptors.
