### PR TITLE
Fixes to complete FrontierAccess plugin thread-safety

### DIFF
--- a/FrontierAccess/src/Connection.cpp
+++ b/FrontierAccess/src/Connection.cpp
@@ -158,6 +158,8 @@ bool coral::FrontierAccess::Connection::isConnected( bool probePhysicalConnectio
 
 void coral::FrontierAccess::Connection::disconnect()
 {
+  boost::mutex::scoped_lock lock( s_lock );
+
   if( ! m_connected )
     return;
 

--- a/FrontierAccess/src/Connection.h
+++ b/FrontierAccess/src/Connection.h
@@ -90,8 +90,6 @@ namespace coral
       std::string m_serverVersion;
       /// The type converter
       TypeConverter*                                   m_typeConverter;
-      /// The connection lock
-      static boost::mutex s_lock;
     };
   } // FrontierAccess namespace
 } // coral namespace

--- a/FrontierAccess/src/Domain.cpp
+++ b/FrontierAccess/src/Domain.cpp
@@ -83,6 +83,8 @@ class CallbackForLobChunkSize
 
 */
 
+boost::mutex coral::FrontierAccess::Domain::s_lock{};
+
 coral::FrontierAccess::Domain::Domain( const std::string& componentName )
   : coral::Service( componentName )
   , m_flavorName( "frontier" )
@@ -157,6 +159,7 @@ coral::FrontierAccess::Domain::newConnection( const std::string& uriString ) con
 {
   try
   {
+    boost::mutex::scoped_lock lock( s_lock );
     // Mandatory Frontier client API initialization
     frontier::init();
   }

--- a/FrontierAccess/src/Domain.cpp
+++ b/FrontierAccess/src/Domain.cpp
@@ -83,8 +83,6 @@ class CallbackForLobChunkSize
 
 */
 
-boost::mutex coral::FrontierAccess::Domain::s_lock{};
-
 coral::FrontierAccess::Domain::Domain( const std::string& componentName )
   : coral::Service( componentName )
   , m_flavorName( "frontier" )
@@ -159,7 +157,7 @@ coral::FrontierAccess::Domain::newConnection( const std::string& uriString ) con
 {
   try
   {
-    boost::mutex::scoped_lock lock( s_lock );
+    boost::mutex::scoped_lock lock( m_properties->lock() );
     // Mandatory Frontier client API initialization
     frontier::init();
   }

--- a/FrontierAccess/src/Domain.h
+++ b/FrontierAccess/src/Domain.h
@@ -88,6 +88,9 @@ namespace coral
 
       /// The domain properties
       DomainProperties* m_properties;
+
+      /// The class global lock
+      static boost::mutex s_lock;
     };
 
   }

--- a/FrontierAccess/src/Domain.h
+++ b/FrontierAccess/src/Domain.h
@@ -89,8 +89,6 @@ namespace coral
       /// The domain properties
       DomainProperties* m_properties;
 
-      /// The class global lock
-      static boost::mutex s_lock;
     };
 
   }

--- a/FrontierAccess/src/DomainProperties.cpp
+++ b/FrontierAccess/src/DomainProperties.cpp
@@ -8,6 +8,8 @@
 
 #include "CoralKernel/Context.h"
 
+boost::mutex coral::FrontierAccess::DomainProperties::s_lock{};
+
 coral::FrontierAccess::DomainProperties::DomainProperties( coral::FrontierAccess::Domain* service ) :
   m_service( service ),
   m_tableSpaceForTables(""),

--- a/FrontierAccess/src/DomainProperties.h
+++ b/FrontierAccess/src/DomainProperties.h
@@ -62,6 +62,9 @@ namespace coral
       /// Access to Web cache control
       const coral::IWebCacheControl& cacheControl() const;
 
+      /// Access to the global lock
+      static boost::mutex& lock();
+
     protected:
       coral::IHandle<coral::IConnectionService> connectionService() const;
 
@@ -80,10 +83,20 @@ namespace coral
 
       /// The chunk size in bytes for a LOB retrieval
       int m_lobChunkSize;
+
+      /// The class global lock
+      static boost::mutex s_lock;
+
     };
 
   }
 
 }
+
+inline boost::mutex& coral::FrontierAccess::DomainProperties::lock()
+{
+  return s_lock;
+}
+
 
 #endif

--- a/FrontierAccess/src/Statement.cpp
+++ b/FrontierAccess/src/Statement.cpp
@@ -349,6 +349,8 @@ namespace coral
 
     void Statement::reset()
     {
+      
+      boost::mutex::scoped_lock lock( m_properties.lock() );
       m_currentRow = 0;
       m_boundInputData  = 0;
       m_boundOutputData  = 0;
@@ -356,8 +358,10 @@ namespace coral
       for( std::vector<const frontier::Request*>::size_type i = 0; i < m_listOfRequests.size(); i++ )
         delete m_listOfRequests[i];
 
-      if( m_session != 0 )
+      if( m_session != 0 ){
         delete m_session;
+	m_session = 0;
+      }
 
       m_listOfRequests.clear();
       m_metaData.clear();


### PR DESCRIPTION
The current Frontier Client library implementation does not support thread safety.  The FrontierAccess plugin enables usage with multi threading by serialising the affected calls to the Client.  We have identified several holes in the coverage of that serialisation. This PR aims to address this problem.