### PR TITLE
Add `const` to `char*` to fix compiler errors with PyString_AsString

### DIFF
--- a/PyCoral/src/IConnectionServiceConfiguration.cpp
+++ b/PyCoral/src/IConnectionServiceConfiguration.cpp
@@ -768,7 +768,7 @@ IConnectionServiceConfiguration_setDefaultAuthenticationService( PyObject* self,
   }
 
   try {
-    char* serviceName;
+    const char* serviceName;
     if ( PyString_Check(args) ) serviceName = PyString_AsString(args);
     else{
       PyErr_SetString( coral::PyCoral::Exception(),
@@ -802,7 +802,7 @@ IConnectionServiceConfiguration_setDefaultLookupService( PyObject* self, PyObjec
   }
 
   try {
-    char* serviceName;
+    const char* serviceName;
     if ( PyString_Check(args) ) serviceName = PyString_AsString(args);
     else{
       PyErr_SetString( coral::PyCoral::Exception(),
@@ -836,7 +836,7 @@ IConnectionServiceConfiguration_setDefaultRelationalService( PyObject* self, PyO
   }
 
   try {
-    char* serviceName;
+    const char* serviceName;
     if ( PyString_Check(args) ) serviceName = PyString_AsString(args);
     else{
       PyErr_SetString( coral::PyCoral::Exception(),
@@ -870,7 +870,7 @@ IConnectionServiceConfiguration_setDefaultMonitoringService( PyObject* self, PyO
   }
 
   try {
-    char* serviceName;
+    const char* serviceName;
     if ( PyString_Check(args) ) serviceName = PyString_AsString(args);
     else{
       PyErr_SetString( coral::PyCoral::Exception(),

--- a/PyCoral/src/IQueryDefinition.cpp
+++ b/PyCoral/src/IQueryDefinition.cpp
@@ -267,7 +267,7 @@ IQueryDefinition_defineSubQuery( PyObject* self, PyObject* args )
     return 0;
   }
   try {
-    char* alias = 0;
+    const char* alias = 0;
     if (PyString_Check(args))
       alias = PyString_AsString(args);
     else{
@@ -360,7 +360,7 @@ IQueryDefinition_groupBy( PyObject* self, PyObject* args )
     return 0;
   }
   try {
-    char* expression = 0;
+    const char* expression = 0;
     if (PyString_Check(args))
       expression = PyString_AsString(args);
     else{
@@ -398,7 +398,7 @@ IQueryDefinition_addToOrderList( PyObject* self, PyObject* args )
     return 0;
   }
   try {
-    char* expression = 0;
+    const char* expression = 0;
     if (PyString_Check(args))
       expression = PyString_AsString(args);
     else{

--- a/PyCoral/src/ISchema.cpp
+++ b/PyCoral/src/ISchema.cpp
@@ -225,7 +225,7 @@ ISchema_existsTable( PyObject* self, PyObject* args)
     return 0;
   }
   try {
-    char* tableName;
+    const char* tableName;
     if (PyString_Check(args))
       tableName = PyString_AsString(args);
     else{
@@ -258,7 +258,7 @@ ISchema_dropTable( PyObject* self, PyObject* args)
     return 0;
   }
   try {
-    char* tableName;
+    const char* tableName;
     if (PyString_Check(args))
       tableName = PyString_AsString(args);
     else{
@@ -291,7 +291,7 @@ ISchema_truncateTable( PyObject* self, PyObject* args)
     return 0;
   }
   try {
-    char* tableName;
+    const char* tableName;
     if (PyString_Check(args))
       tableName = PyString_AsString(args);
     else{
@@ -354,7 +354,7 @@ ISchema_dropIfExistsTable( PyObject* self, PyObject* args)
     return 0;
   }
   try {
-    char* tableName;
+    const char* tableName;
     if (PyString_Check(args))
       tableName = PyString_AsString(args);
     else{
@@ -445,7 +445,7 @@ ISchema_tableHandle( PyObject* self, PyObject* args)
     return 0;
   }
   try {
-    char* tableName = 0;
+    const char* tableName = 0;
     if (PyString_Check(args))
       tableName = PyString_AsString(args);
     else{
@@ -595,7 +595,7 @@ ISchema_existsView( PyObject* self, PyObject* args)
     return 0;
   }
   try {
-    char* viewName;
+    const char* viewName;
     if (PyString_Check(args))
       viewName = PyString_AsString(args);
     else{
@@ -628,7 +628,7 @@ ISchema_dropView( PyObject* self, PyObject* args)
     return 0;
   }
   try {
-    char* viewName;
+    const char* viewName;
     if (PyString_Check(args))
       viewName = PyString_AsString(args);
     else{
@@ -661,7 +661,7 @@ ISchema_dropIfExistsView( PyObject* self, PyObject* args)
     return 0;
   }
   try {
-    char* viewName;
+    const char* viewName;
     if (PyString_Check(args))
       viewName = PyString_AsString(args);
     else{
@@ -733,7 +733,7 @@ ISchema_viewHandle( PyObject* self, PyObject* args)
     return 0;
   }
   try {
-    char* tViewName;
+    const char* tViewName;
     if (PyString_Check(args))
       tViewName = PyString_AsString(args);
     else{

--- a/PyCoral/src/ISessionProxy.cpp
+++ b/PyCoral/src/ISessionProxy.cpp
@@ -239,7 +239,7 @@ ISessionProxy_schema( PyObject* self, PyObject* args )
     return 0;
   }
   try {
-    char* schemaName;
+    const char* schemaName;
     if (PyString_Check(args))
       schemaName = PyString_AsString(args);
     else{

--- a/PyCoral/src/ITableSchemaEditor.cpp
+++ b/PyCoral/src/ITableSchemaEditor.cpp
@@ -233,7 +233,7 @@ ITableSchemaEditor_dropColumn( PyObject* self, PyObject* args)
     return 0;
   }
   try {
-    char *tableSchemaName;
+    const char *tableSchemaName;
     if (PyString_Check(args))
       tableSchemaName = PyString_AsString(args);
     else{
@@ -673,7 +673,7 @@ ITableSchemaEditor_dropIndex( PyObject* self, PyObject* args)
     return 0;
   }
   try {
-    char *indexName;
+    const char *indexName;
     if (PyString_Check(args))
       indexName = PyString_AsString(args);
     else{
@@ -828,7 +828,7 @@ ITableSchemaEditor_dropForeignKey( PyObject* self, PyObject* args)
     return 0;
   }
   try {
-    char *name;
+    const char *name;
     if (PyString_Check(args))
       name = PyString_AsString(args);
     else{

--- a/PyCoral/src/ITypeConverter.cpp
+++ b/PyCoral/src/ITypeConverter.cpp
@@ -226,7 +226,7 @@ ITypeConverter_defaultCppTypeForSqlType( PyObject* self, PyObject* args )
     return 0;
   }
   try {
-    char* defaultCpp;
+    const char* defaultCpp;
     std::string theDefaultCpp;
     if (PyString_Check(args))
       defaultCpp = PyString_AsString(args);
@@ -260,7 +260,7 @@ ITypeConverter_cppTypeForSqlType( PyObject* self, PyObject* args )
     return 0;
   }
   try {
-    char* cpp;
+    const char* cpp;
     std::string theCpp;
     if (PyString_Check(args))
       cpp = PyString_AsString(args);
@@ -321,7 +321,7 @@ ITypeConverter_defaultSqlTypeForCppType( PyObject* self, PyObject* args )
     return 0;
   }
   try {
-    char* defaultSql;
+    const char* defaultSql;
     std::string theDefaultSql;
     if (PyString_Check(args))
       defaultSql = PyString_AsString(args);
@@ -356,7 +356,7 @@ ITypeConverter_sqlTypeForCppType( PyObject* self, PyObject* args )
     return 0;
   }
   try {
-    char* sql;
+    const char* sql;
     std::string theSql;
     if (PyString_Check(args))
       sql = PyString_AsString(args);

--- a/PyCoral/src/IViewFactory.cpp
+++ b/PyCoral/src/IViewFactory.cpp
@@ -173,7 +173,7 @@ IViewFactory_create( PyObject* self, PyObject* args)
     return 0;
   }
   try {
-    char* tViewName;
+    const char* tViewName;
     if (PyString_Check(args))
       tViewName = PyString_AsString(args);
     else{
@@ -229,7 +229,7 @@ IViewFactory_createOrReplace( PyObject* self, PyObject* args)
     return 0;
   }
   try {
-    char* tViewName;
+    const char* tViewName;
     if (PyString_Check(args))
       tViewName = PyString_AsString(args);
     else{

--- a/PyCoral/src/TableDescription.cpp
+++ b/PyCoral/src/TableDescription.cpp
@@ -233,7 +233,7 @@ TableDescription_setName( PyObject* self, PyObject* args)
     return 0;
   }
   try {
-    char* tableName;
+    const char* tableName;
     if (PyString_Check(args))
       tableName = PyString_AsString(args);
     else{
@@ -266,7 +266,7 @@ TableDescription_setType( PyObject* self, PyObject* args)
     return 0;
   }
   try {
-    char* tableType;
+    const char* tableType;
     if (PyString_Check(args))
       tableType = PyString_AsString(args);
     else{
@@ -298,7 +298,7 @@ TableDescription_setTableSpaceName( PyObject* self, PyObject* args)
     return 0;
   }
   try {
-    char* tableSpaceName;
+    const char* tableSpaceName;
     if (PyString_Check(args))
       tableSpaceName = PyString_AsString(args);
     else{


### PR DESCRIPTION
This harmless change fixes compile errors that I have when building on
my Arch Linux laptop with Python 3.10.